### PR TITLE
Update skopeo to 1.23.0 (with refreshed conda-relative-paths patch)

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,16 +12,24 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
+      export MINIFORGE_HOME=$(tools_install_dir)
+      export CONDA_BLD_PATH=$(build_workspace_dir)
       export CI=azure
       export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
       export remote_url=$(Build.Repository.Uri)

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,15 +23,23 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code
@@ -41,11 +49,13 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -65,6 +75,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
@@ -72,6 +84,8 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
@@ -90,6 +104,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -102,10 +118,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/conda-forge/skopeo-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/skopeo-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -31,31 +38,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6608&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/skopeo-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6608&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/skopeo-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6608&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/skopeo-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_arm64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6608&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/skopeo-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "skopeo-feedstock"
-version = "3.60.0"  # conda-smithy version used to generate this file
+version = "3.62.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/skopeo-feedstock"
 authors = ["@conda-forge/skopeo"]
 channels = ["conda-forge"]
@@ -13,7 +13,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]
-conda-build = ">=24.1"
+conda-build = ">=26.3"
 conda-forge-ci-setup = "4.*"
 rattler-build = "*"
 

--- a/recipe/0001-Allow-relative-paths-for-system-config-files.patch
+++ b/recipe/0001-Allow-relative-paths-for-system-config-files.patch
@@ -1,10 +1,48 @@
-diff --git a/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_v2.go b/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_v2.go
---- a/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_v2.go
-+++ b/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_v2.go
-@@ -22,6 +22,27 @@ import (
- 	"go.podman.io/storage/pkg/regexp"
+diff --git a/vendor/go.podman.io/storage/pkg/configfile/parse.go b/vendor/go.podman.io/storage/pkg/configfile/parse.go
+index 9a9ea71..890e250 100644
+--- a/vendor/go.podman.io/storage/pkg/configfile/parse.go
++++ b/vendor/go.podman.io/storage/pkg/configfile/parse.go
+@@ -150,6 +150,8 @@ func getSearchPaths(conf *File) (SearchPaths, bool, error) {
+ 		defaultConfig = filepath.Join(defaultConfig, configFileName)
+ 		if conf.RootForImplicitAbsolutePaths != "" {
+ 			defaultConfig = filepath.Join(conf.RootForImplicitAbsolutePaths, defaultConfig)
++		} else {
++			defaultConfig = condaFallbackToExeRelPath(defaultConfig)
+ 		}
+ 	}
+ 
+@@ -159,6 +161,8 @@ func getSearchPaths(conf *File) (SearchPaths, bool, error) {
+ 		overrideConfig = filepath.Join(overrideConfig, configFileName)
+ 		if conf.RootForImplicitAbsolutePaths != "" {
+ 			overrideConfig = filepath.Join(conf.RootForImplicitAbsolutePaths, overrideConfig)
++		} else {
++			overrideConfig = condaFallbackToExeRelPath(overrideConfig)
+ 		}
+ 	}
+ 
+diff --git a/vendor/go.podman.io/storage/pkg/configfile/path.go b/vendor/go.podman.io/storage/pkg/configfile/path.go
+index d9443dd..329c930 100644
+--- a/vendor/go.podman.io/storage/pkg/configfile/path.go
++++ b/vendor/go.podman.io/storage/pkg/configfile/path.go
+@@ -2,6 +2,14 @@
+ 
+ package configfile
+ 
++import (
++	"os"
++	"path/filepath"
++	"strings"
++
++	"github.com/sirupsen/logrus"
++)
++
+ const (
+ 	// builtinSystemConfigPath is the location for the default config files shipped by the distro/vendor.
+ 	builtinSystemConfigPath = "/usr/share/containers"
+@@ -10,6 +18,31 @@ const (
+ 	builtinAdminOverrideConfigPath = "/etc/containers"
  )
-
+ 
 +// For Conda environments we transform default configuration paths like so:
 +// (This assumes the executable always resides at PREFIX/bin/executable!)
 +//   /etc/path -> PREFIX/bin/../etc/path -> PREFIX/etc/path
@@ -17,7 +55,11 @@ diff --git a/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_
 +	relativePath := strings.TrimPrefix(path, "/usr")
 +	return filepath.Join(filepath.Dir(filepath.Dir(exePath)), relativePath)
 +}
++
 +func condaFallbackToExeRelPath(path string) string {
++	if path == "" {
++		return path
++	}
 +	if _, err := os.Stat(path); err == nil {
 +		return path
 +	}
@@ -26,79 +68,6 @@ diff --git a/vendor/go.podman.io/image/v5/pkg/sysregistriesv2/system_registries_
 +	return condaPath
 +}
 +
- // systemRegistriesConfPath is the path to the system-wide registry
- // configuration file and is used to add/subtract potential registries for
- // obtaining images.  You can override this at build time with
-@@ -587,7 +608,7 @@ func newConfigWrapperWithHomeDir(ctx *types.SystemContext, homeDir string) confi
- 	} else if ctx != nil && ctx.RootForImplicitAbsolutePaths != "" {
- 		wrapper.configPath = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfPath)
- 	} else {
--		wrapper.configPath = systemRegistriesConfPath
-+		wrapper.configPath = condaFallbackToExeRelPath(systemRegistriesConfPath)
- 	}
-
- 	// potentially use both system and per-user dirs if not using per-user config file
-@@ -598,7 +619,7 @@ func newConfigWrapperWithHomeDir(ctx *types.SystemContext, homeDir string) confi
- 		wrapper.configDirPath = filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesConfDirPath)
- 		wrapper.userConfigDirPath = userRegistriesDirPath
- 	} else {
--		wrapper.configDirPath = systemRegistriesConfDirPath
-+		wrapper.configDirPath = condaFallbackToExeRelPath(systemRegistriesConfDirPath)
- 		wrapper.userConfigDirPath = userRegistriesDirPath
- 	}
-
-diff --git a/vendor/go.podman.io/image/v5/signature/policy_config.go b/vendor/go.podman.io/image/v5/signature/policy_config.go
---- a/vendor/go.podman.io/image/v5/signature/policy_config.go
-+++ b/vendor/go.podman.io/image/v5/signature/policy_config.go
-@@ -19,7 +19,9 @@ import (
- 	"fmt"
- 	"os"
- 	"path/filepath"
-+	"strings"
-
-+	"github.com/sirupsen/logrus"
- 	"go.podman.io/image/v5/docker/reference"
- 	"go.podman.io/image/v5/signature/internal"
- 	"go.podman.io/image/v5/transports"
-@@ -28,6 +30,25 @@ import (
- 	"go.podman.io/storage/pkg/homedir"
- 	"go.podman.io/storage/pkg/regexp"
- )
-+
-+// For Conda environments we transform default configuration paths like so:
-+// (This assumes the executable always resides at PREFIX/bin/executable!)
-+//   /etc/path -> PREFIX/bin/../etc/path -> PREFIX/etc/path
-+//   /usr/share/path -> PREFIX/bin/../share/path -> PREFIX/share/path
-+func condaExeRelPath(path string) string {
-+	exePath, err := os.Executable()
-+	if err != nil {
-+		return path
-+	}
-+	relativePath := strings.TrimPrefix(path, "/usr")
-+	return filepath.Join(filepath.Dir(filepath.Dir(exePath)), relativePath)
-+}
-+func condaFallbackToExeRelPath(path string) string {
-+	if _, err := os.Stat(path); err == nil {
-+		return path
-+	}
-+	return condaExeRelPath(path)
-+}
-
- // systemDefaultPolicyPath is the policy path used for DefaultPolicy().
- // You can override this at build time with
-@@ -83,7 +104,14 @@ func defaultPolicyPathWithHomeDir(sys *types.SystemContext, homeDir string, syst
- 	if err := fileutils.Exists(systemPolicyPath); err == nil {
- 		return systemPolicyPath, nil
- 	}
--	return "", fmt.Errorf("no policy.json file found at any of the following: %q, %q", userPolicyFilePath, systemPolicyPath)
-+	condaPath := condaExeRelPath(systemPolicyPath)
-+	if condaPath != systemPolicyPath {
-+		if err := fileutils.Exists(condaPath); err == nil {
-+			logrus.Debugf("Using Conda environment policy path %q (system path %q not found)", condaPath, systemPolicyPath)
-+			return condaPath, nil
-+		}
-+	}
-+	return "", fmt.Errorf("no policy.json file found at any of the following: %q, %q, %q", userPolicyFilePath, systemPolicyPath, condaPath)
+ func getAdminOverrideConfigPath() string {
+ 	return builtinAdminOverrideConfigPath
  }
-
- // NewPolicyFromFile returns a policy configured in the specified file.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "1.22.2"
+  version: "1.23.0"
 
 package:
   name: skopeo
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/containers/skopeo/archive/v${{ version }}.tar.gz
-  sha256: b6e1f208c1048f7a80613e8154774e6a3fdc891aeb45325c8ed905be4dee48d8
+  sha256: de96bfc2bb523c852af675ffdadd934484812ce190aa8620e1d5fd6c51442e25
   target_directory: src
   patches:
     - 0001-Allow-relative-paths-for-system-config-files.patch


### PR DESCRIPTION
Supersedes (and incorporates) the autotick-bot's #58, which fails CI because the existing `0001-Allow-relative-paths-for-system-config-files.patch` no longer applies to skopeo 1.23.0.

### What changed upstream
skopeo 1.23.0 vendors a refactored `containers/storage` `configfile` package. The functions the old patch targeted (`newConfigWrapperWithHomeDir` in `sysregistriesv2/system_registries_v2.go` and `defaultPolicyPathWithHomeDir` in `signature/policy_config.go`) no longer exist; both registries.conf and policy.json lookups now go through a single `configfile.GetSearchPaths` / `configfile.Read` machinery in `vendor/go.podman.io/storage/pkg/configfile/`.

### Fix
Rewrote the patch to hook into the new central path-resolution code in `vendor/go.podman.io/storage/pkg/configfile/path.go` and `parse.go`. Helpers (`condaExeRelPath`, `condaFallbackToExeRelPath`) are added in `path.go`; `getSearchPaths` in `parse.go` now wraps `defaultConfig` and `overrideConfig` with the conda fallback whenever `RootForImplicitAbsolutePaths` isn't set. Because both registries and policy files now use this same code path, a single fix covers both cases.

### Verification
Built skopeo 1.23.0 locally with the new patch and confirmed:
```
$ ./skopeo --debug inspect --override-arch amd64 --override-os linux docker://docker.io/alpine 2>&1 | grep 'Using Conda'
... level=debug msg="Using Conda environment config path .../share/containers/registries.conf (system path /usr/share/containers/registries.conf not found)"
... level=debug msg="Using Conda environment config path .../etc/containers/registries.conf (system path /etc/containers/registries.conf not found)"
...
```
which is what the in-recipe test greps for.

cc @epruesse @bgruening @mbargull @dhirschfeld